### PR TITLE
fix: export every note, own the cleanup, resolve the export path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+* Fixed: every note is now exported. Reads were capped at 100 notes, and the cleanup then deleted the backup files of everything past that limit (#5)
+* Fixed: cleanup only removes files the plugin itself wrote, tracked in `.autopush-manifest.json`. Pointing the export at a directory holding your own markdown no longer deletes it (#7)
+* Fixed: `~` in the export path is expanded. Notes previously landed in a directory literally named `~` under Inkdrop's working directory (#8)
+* Added: `npm test` runs a test suite covering pagination, path resolution and cleanup ownership. No new dependency — it uses Node's built-in test runner
+
+**Upgrading:** if you kept the default export path, your old backup is still in that stray `~` directory and the plugin now writes to `$HOME/Documents/InkdropNotes` instead. A notification points you to the old location on startup. Nothing is moved or deleted automatically — that directory's `.git/config` holds your GitHub token in cleartext, so review it before removing it. The first push to an already-populated repository from the new directory will be rejected for unrelated histories (#9).
+
 ## 0.0.4 - Inkdrop 6 Compatibility
 * Fixed: `engines.inkdrop` widened to `>=5.3.1 <7` — the plugin could not be installed on Inkdrop 6, and Inkdrop 5 remains supported
 * Fixed: `repository.type` set to `git` with the `.git` suffix in the URL

--- a/lib/autopush-notes.js
+++ b/lib/autopush-notes.js
@@ -5,6 +5,9 @@ const os = require("os");
 const path = require("path");
 const { exec } = require("child_process");
 
+// Tracks the files this plugin wrote, so cleanup never touches anything else.
+const MANIFEST_FILENAME = ".autopush-manifest.json";
+
 // db.notes.all() defaults to limit: 20, so every read must page explicitly.
 const NOTE_PAGE_SIZE = 500;
 
@@ -250,21 +253,59 @@ module.exports = {
     this.cleanupDeletedNotes(exportPath, currentNoteFiles);
   },
 
-  // Remove local files for notes that no longer exist in the database
+  // Remove local files for notes that no longer exist in the database.
+  // Only files recorded in the manifest are ever deleted: the export directory may
+  // hold markdown the user owns, and a missing manifest means we own nothing yet.
   cleanupDeletedNotes(exportPath, currentNoteFiles) {
-    try {
-      const files = fs.readdirSync(exportPath);
-      const mdFiles = files.filter((file) => file.endsWith(".md"));
+    const manifestPath = path.join(exportPath, MANIFEST_FILENAME);
+    const previouslyWritten = this.readManifest(manifestPath);
 
-      mdFiles.forEach((file) => {
-        if (!currentNoteFiles.has(file)) {
-          const filePath = path.join(exportPath, file);
-          console.log("Removing deleted note file:", file);
-          fs.unlinkSync(filePath);
+    previouslyWritten.forEach((filename) => {
+      if (currentNoteFiles.has(filename)) return;
+
+      // A manifest entry is a bare filename. Anything else could escape the
+      // export directory, so drop it rather than resolve it.
+      if (filename !== path.basename(filename)) {
+        console.error("Ignoring suspicious manifest entry:", filename);
+        return;
+      }
+
+      try {
+        fs.unlinkSync(path.join(exportPath, filename));
+        console.log("Removing deleted note file:", filename);
+      } catch (error) {
+        if (error.code !== "ENOENT") {
+          console.error(`Error removing ${filename}:`, error);
         }
-      });
+      }
+    });
+
+    // Sorted: the manifest is committed to the backup repository, so an unchanged
+    // note set has to serialise to identical bytes or every run dirties git.
+    fs.writeFileSync(
+      manifestPath,
+      `${JSON.stringify([...currentNoteFiles].sort(), null, 2)}\n`,
+      "utf8",
+    );
+  },
+
+  readManifest(manifestPath) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+      if (!Array.isArray(parsed)) {
+        console.error("Export manifest is not an array, adopting no files.");
+        return [];
+      }
+
+      return parsed.filter((entry) => typeof entry === "string");
     } catch (error) {
-      console.error("Error cleaning up deleted notes:", error);
+      // Absent on the first run and after an upgrade: adopt the directory as it
+      // stands and delete nothing. Unreadable is treated the same way on purpose.
+      if (error.code !== "ENOENT") {
+        console.error("Could not read the export manifest:", error);
+      }
+      return [];
     }
   },
 

--- a/lib/autopush-notes.js
+++ b/lib/autopush-notes.js
@@ -1,8 +1,12 @@
 "use babel";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { exec } = require("child_process");
+
+// Versions before the "~" fix wrote here, relative to the Inkdrop process CWD.
+const LEGACY_EXPORT_PATH = "~/Documents/InkdropNotes";
 
 module.exports = {
   backupInterval: null, // Store autosaving interval
@@ -33,6 +37,34 @@ module.exports = {
       "autopush-notes:exportAndPush": () => this.exportAndPushNotes(),
       "autopush-notes:toggle": () => this.toggleAutoBackup(),
     });
+
+    this.warnAboutLegacyExportPath();
+  },
+
+  // Earlier versions never expanded "~", so notes landed in a stray directory.
+  // Point the user at it instead of moving it: its .git/config holds a cleartext
+  // token, and relocating that silently is not ours to decide.
+  warnAboutLegacyExportPath() {
+    const legacyPath = this.findLegacyExportPath();
+    if (!legacyPath) return;
+
+    this.showNotificationSafely(
+      `Autopush Notes now resolves "~" correctly, so backups moved to the path you configured. ` +
+        `Your previous export is still at ${legacyPath}. Its .git/config contains your GitHub ` +
+        `token in cleartext — delete the directory once you have checked its contents.`,
+      "warning",
+    );
+  },
+
+  findLegacyExportPath() {
+    try {
+      const legacyPath = path.resolve(LEGACY_EXPORT_PATH);
+      if (legacyPath === this.resolveExportPath()) return null;
+      return fs.existsSync(legacyPath) ? legacyPath : null;
+    } catch (error) {
+      console.error("Could not check for a legacy export directory:", error);
+      return null;
+    }
   },
 
   deactivate() {
@@ -106,7 +138,7 @@ module.exports = {
   },
 
   // Helper function to display notifications safely
-  showNotificationSafely(message) {
+  showNotificationSafely(message, type = "info") {
     try {
       console.log("Attempting to display notification with message: ", message);
       // Add validation before displaying notification
@@ -118,7 +150,7 @@ module.exports = {
       if (inkdrop && inkdrop.notifications) {
         inkdrop.notifications.add({
           message: message,
-          type: "info",
+          type: type,
           dismissable: true, // Make notification dismissable
         });
       } else {
@@ -131,12 +163,38 @@ module.exports = {
     }
   },
 
+  // Node's fs API does not expand "~" — that is a shell convention. Resolve it
+  // here, once, so every call site agrees on where the export lives.
+  resolveExportPath() {
+    const configured = inkdrop.config.get("autopush-notes.localExportPath");
+
+    if (typeof configured !== "string" || configured.trim() === "") {
+      throw new Error("Export path is not configured");
+    }
+
+    const trimmed = configured.trim();
+
+    if (trimmed === "~" || trimmed.startsWith("~/")) {
+      return path.resolve(path.join(os.homedir(), trimmed.slice(1)));
+    }
+
+    // "~user" needs a passwd lookup we cannot do; refuse rather than mishandle.
+    if (trimmed.startsWith("~")) {
+      throw new Error(
+        `Unsupported "~user" syntax in the export path: ${trimmed}. Use an absolute path.`,
+      );
+    }
+
+    return path.resolve(trimmed);
+  },
+
   // Export notes locally and clean up deleted notes
   async exportNotesLocally() {
-    const exportPath = inkdrop.config.get("autopush-notes.localExportPath");
+    const exportPath = this.resolveExportPath();
     console.log("Exporting notes locally to:", exportPath);
 
     const db = inkdrop.main.dataStore.getLocalDB();
+
     const allNotes = await db.notes.all({ limit: 100 });
     const notesArray = allNotes.docs; // access via docs property
 
@@ -156,7 +214,7 @@ module.exports = {
       currentNoteFiles.add(filename);
     });
 
-    console.log("Notes export completed!");
+    console.log(`Notes export completed: ${currentNoteFiles.size} files.`);
 
     // Clean up deleted notes - remove .md files that don't correspond to current notes
     this.cleanupDeletedNotes(exportPath, currentNoteFiles);
@@ -190,7 +248,7 @@ module.exports = {
   async pushNotesToGitHub() {
     const githubToken = inkdrop.config.get("autopush-notes.githubToken");
     const githubRepo = inkdrop.config.get("autopush-notes.githubRepo");
-    const exportPath = inkdrop.config.get("autopush-notes.localExportPath");
+    const exportPath = this.resolveExportPath();
 
     if (!githubToken || !githubRepo) {
       console.error("GitHub token or repository is not configured!");

--- a/lib/autopush-notes.js
+++ b/lib/autopush-notes.js
@@ -5,6 +5,9 @@ const os = require("os");
 const path = require("path");
 const { exec } = require("child_process");
 
+// db.notes.all() defaults to limit: 20, so every read must page explicitly.
+const NOTE_PAGE_SIZE = 500;
+
 // Versions before the "~" fix wrote here, relative to the Inkdrop process CWD.
 const LEGACY_EXPORT_PATH = "~/Documents/InkdropNotes";
 
@@ -188,6 +191,32 @@ module.exports = {
     return path.resolve(trimmed);
   },
 
+  // Read the whole note database, page by page. totalRows lets us prove the read
+  // was complete instead of assuming it because nothing threw.
+  async fetchAllNotes(db) {
+    const notes = [];
+    let expectedTotal = null;
+    let skip = 0;
+
+    for (;;) {
+      const page = await db.notes.all({ limit: NOTE_PAGE_SIZE, skip });
+
+      if (expectedTotal === null) expectedTotal = page.totalRows;
+      notes.push(...page.docs);
+
+      if (page.docs.length < NOTE_PAGE_SIZE) break;
+      skip += NOTE_PAGE_SIZE;
+    }
+
+    if (typeof expectedTotal === "number" && notes.length !== expectedTotal) {
+      throw new Error(
+        `Incomplete read from the note database: got ${notes.length} of ${expectedTotal} notes`,
+      );
+    }
+
+    return notes;
+  },
+
   // Export notes locally and clean up deleted notes
   async exportNotesLocally() {
     const exportPath = this.resolveExportPath();
@@ -195,8 +224,9 @@ module.exports = {
 
     const db = inkdrop.main.dataStore.getLocalDB();
 
-    const allNotes = await db.notes.all({ limit: 100 });
-    const notesArray = allNotes.docs; // access via docs property
+    // Read everything before touching the disk. A failure midway must not leave a
+    // partial export behind, because cleanup treats the written set as authoritative.
+    const notesArray = await this.fetchAllNotes(db);
 
     if (!fs.existsSync(exportPath)) {
       fs.mkdirSync(exportPath, { recursive: true });

--- a/lib/autopush-notes.test.js
+++ b/lib/autopush-notes.test.js
@@ -6,6 +6,8 @@ const path = require("path");
 
 const plugin = require("./autopush-notes");
 
+const MANIFEST = ".autopush-manifest.json";
+
 // A stand-in for inkdrop.main.dataStore.getLocalDB(). Serves `count` notes and
 // records every query, so tests can assert the pagination itself.
 function fakeDb(count, { failAtSkip = null, reportedTotal = null } = {}) {
@@ -65,6 +67,10 @@ function chdir(t, dir) {
   const previous = process.cwd();
   process.chdir(dir);
   t.after(() => process.chdir(previous));
+}
+
+function readManifest(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, MANIFEST), "utf8"));
 }
 
 test("fetchAllNotes reads every note past the first page", async () => {
@@ -176,6 +182,71 @@ test("no legacy warning when the stray directory is absent", (t) => {
   assert.deepEqual(notifications, []);
 });
 
+test("cleanup deletes nothing when no manifest exists", (t) => {
+  const dir = tempDir(t);
+  fs.writeFileSync(path.join(dir, "someone-elses-note.md"), "not ours");
+  fs.writeFileSync(path.join(dir, "Kept.md"), "ours");
+
+  plugin.cleanupDeletedNotes(dir, new Set(["Kept.md"]));
+
+  assert.ok(fs.existsSync(path.join(dir, "someone-elses-note.md")));
+  assert.ok(fs.existsSync(path.join(dir, "Kept.md")));
+  assert.deepEqual(readManifest(dir), ["Kept.md"]);
+});
+
+test("cleanup removes a file it wrote once the note is gone", (t) => {
+  const dir = tempDir(t);
+  fs.writeFileSync(path.join(dir, "Kept.md"), "ours");
+  fs.writeFileSync(path.join(dir, "Removed.md"), "ours too");
+  fs.writeFileSync(
+    path.join(dir, MANIFEST),
+    JSON.stringify(["Kept.md", "Removed.md"]),
+  );
+
+  plugin.cleanupDeletedNotes(dir, new Set(["Kept.md"]));
+
+  assert.ok(fs.existsSync(path.join(dir, "Kept.md")));
+  assert.ok(!fs.existsSync(path.join(dir, "Removed.md")));
+});
+
+test("cleanup never deletes markdown it does not own, manifest or not", (t) => {
+  const dir = tempDir(t);
+  fs.writeFileSync(path.join(dir, "Ours.md"), "ours");
+  fs.writeFileSync(path.join(dir, "Obsidian vault note.md"), "theirs");
+  fs.writeFileSync(path.join(dir, MANIFEST), JSON.stringify(["Ours.md"]));
+
+  plugin.cleanupDeletedNotes(dir, new Set(["Ours.md"]));
+
+  assert.ok(fs.existsSync(path.join(dir, "Obsidian vault note.md")));
+});
+
+test("cleanup ignores a manifest entry that would escape the export directory", (t) => {
+  const dir = tempDir(t);
+  const outside = path.join(dir, "outside.md");
+  const inner = path.join(dir, "inner");
+  fs.mkdirSync(inner);
+  fs.writeFileSync(outside, "must survive");
+  fs.writeFileSync(path.join(inner, MANIFEST), JSON.stringify(["../outside.md"]));
+
+  plugin.cleanupDeletedNotes(inner, new Set());
+
+  assert.ok(fs.existsSync(outside), "traversal entry must not be followed");
+});
+
+test("cleanup writes a byte-stable manifest across runs", (t) => {
+  const dir = tempDir(t);
+
+  plugin.cleanupDeletedNotes(dir, new Set(["b.md", "a.md", "c.md"]));
+  const first = fs.readFileSync(path.join(dir, MANIFEST), "utf8");
+
+  // Same notes, different iteration order — the file must not change.
+  plugin.cleanupDeletedNotes(dir, new Set(["c.md", "a.md", "b.md"]));
+  const second = fs.readFileSync(path.join(dir, MANIFEST), "utf8");
+
+  assert.equal(first, second);
+  assert.deepEqual(JSON.parse(first), ["a.md", "b.md", "c.md"]);
+});
+
 test("export writes every note of a 250-note vault", async (t) => {
   const dir = tempDir(t);
   stubInkdrop(t, { exportPath: dir, db: fakeDb(250) });
@@ -184,6 +255,7 @@ test("export writes every note of a 250-note vault", async (t) => {
 
   const written = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
   assert.equal(written.length, 250);
+  assert.equal(readManifest(dir).length, 250);
 });
 
 test("two consecutive exports leave the directory byte-identical", async (t) => {

--- a/lib/autopush-notes.test.js
+++ b/lib/autopush-notes.test.js
@@ -1,0 +1,100 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const plugin = require("./autopush-notes");
+
+function tempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "autopush-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function stubInkdrop(t, { exportPath, db } = {}) {
+  const previous = global.inkdrop;
+  const notifications = [];
+  global.inkdrop = {
+    config: {
+      get(key) {
+        if (key === "autopush-notes.localExportPath") return exportPath;
+        return undefined;
+      },
+    },
+    notifications: { add: (n) => notifications.push(n) },
+    main: { dataStore: { getLocalDB: () => db } },
+  };
+  t.after(() => {
+    global.inkdrop = previous;
+  });
+  return notifications;
+}
+
+// The stray directory is resolved against the process CWD, so tests move there.
+function chdir(t, dir) {
+  const previous = process.cwd();
+  process.chdir(dir);
+  t.after(() => process.chdir(previous));
+}
+
+test("resolveExportPath expands a leading ~ to the home directory", (t) => {
+  stubInkdrop(t, { exportPath: "~/Documents/InkdropNotes" });
+
+  assert.equal(
+    plugin.resolveExportPath(),
+    path.join(os.homedir(), "Documents", "InkdropNotes"),
+  );
+});
+
+test("resolveExportPath leaves an absolute path untouched", (t) => {
+  stubInkdrop(t, { exportPath: "/var/tmp/notes-backup" });
+
+  assert.equal(plugin.resolveExportPath(), "/var/tmp/notes-backup");
+});
+
+test("resolveExportPath rejects ~user syntax instead of mishandling it", (t) => {
+  stubInkdrop(t, { exportPath: "~someone/notes" });
+
+  assert.throws(() => plugin.resolveExportPath(), /~user/);
+});
+
+test("resolveExportPath rejects an unconfigured path", (t) => {
+  stubInkdrop(t, { exportPath: "   " });
+
+  assert.throws(() => plugin.resolveExportPath(), /not configured/);
+});
+
+test("a stray legacy export directory is reported, never moved", (t) => {
+  const root = tempDir(t);
+  const legacy = path.join(root, "~", "Documents", "InkdropNotes");
+  fs.mkdirSync(legacy, { recursive: true });
+  fs.writeFileSync(path.join(legacy, "Old note.md"), "still here");
+
+  chdir(t, root);
+  const notifications = stubInkdrop(t, { exportPath: "/var/tmp/notes-backup" });
+
+  plugin.warnAboutLegacyExportPath();
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].type, "warning");
+  assert.match(notifications[0].message, /token in cleartext/);
+  assert.ok(
+    notifications[0].message.includes(legacy),
+    "the notification must name the stray directory",
+  );
+  assert.ok(
+    fs.existsSync(path.join(legacy, "Old note.md")),
+    "nothing may be moved or deleted",
+  );
+});
+
+test("no legacy warning when the stray directory is absent", (t) => {
+  const root = tempDir(t);
+  chdir(t, root);
+  const notifications = stubInkdrop(t, { exportPath: "/var/tmp/notes-backup" });
+
+  plugin.warnAboutLegacyExportPath();
+
+  assert.deepEqual(notifications, []);
+});

--- a/lib/autopush-notes.test.js
+++ b/lib/autopush-notes.test.js
@@ -6,6 +6,35 @@ const path = require("path");
 
 const plugin = require("./autopush-notes");
 
+// A stand-in for inkdrop.main.dataStore.getLocalDB(). Serves `count` notes and
+// records every query, so tests can assert the pagination itself.
+function fakeDb(count, { failAtSkip = null, reportedTotal = null } = {}) {
+  const notes = Array.from({ length: count }, (_, i) => ({
+    _id: `note:${i}`,
+    title: `Note ${String(i).padStart(4, "0")}`,
+    body: `Body of note ${i}`,
+  }));
+
+  const calls = [];
+
+  return {
+    calls,
+    notes: {
+      async all({ limit, skip }) {
+        calls.push({ limit, skip });
+        if (failAtSkip !== null && skip === failAtSkip) {
+          throw new Error("database unavailable");
+        }
+        return {
+          totalRows: reportedTotal === null ? notes.length : reportedTotal,
+          docs: notes.slice(skip, skip + limit),
+          includeDocs: true,
+        };
+      },
+    },
+  };
+}
+
 function tempDir(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "autopush-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -37,6 +66,54 @@ function chdir(t, dir) {
   process.chdir(dir);
   t.after(() => process.chdir(previous));
 }
+
+test("fetchAllNotes reads every note past the first page", async () => {
+  const db = fakeDb(250);
+  const notes = await plugin.fetchAllNotes(db);
+
+  assert.equal(notes.length, 250);
+  assert.equal(notes[0]._id, "note:0");
+  assert.equal(notes[249]._id, "note:249");
+});
+
+test("fetchAllNotes never relies on the database default limit of 20", async () => {
+  const db = fakeDb(1200);
+  await plugin.fetchAllNotes(db);
+
+  assert.ok(db.calls.length > 1, "expected more than one page");
+  assert.ok(
+    db.calls.every((call) => typeof call.limit === "number" && call.limit > 20),
+    `every call must pass an explicit limit, got ${JSON.stringify(db.calls)}`,
+  );
+});
+
+test("fetchAllNotes terminates on an exactly-full final page", async () => {
+  const db = fakeDb(1000);
+  const notes = await plugin.fetchAllNotes(db);
+
+  assert.equal(notes.length, 1000);
+  assert.equal(db.calls.length, 3, "expected a final empty page to stop the loop");
+});
+
+test("fetchAllNotes handles an empty database", async () => {
+  const notes = await plugin.fetchAllNotes(fakeDb(0));
+  assert.deepEqual(notes, []);
+});
+
+test("fetchAllNotes rejects a read that does not match totalRows", async () => {
+  const db = fakeDb(10, { reportedTotal: 250 });
+
+  await assert.rejects(
+    () => plugin.fetchAllNotes(db),
+    /Incomplete read.*got 10 of 250/,
+  );
+});
+
+test("fetchAllNotes propagates a failure that happens mid-pagination", async () => {
+  const db = fakeDb(1200, { failAtSkip: 500 });
+
+  await assert.rejects(() => plugin.fetchAllNotes(db), /database unavailable/);
+});
 
 test("resolveExportPath expands a leading ~ to the home directory", (t) => {
   stubInkdrop(t, { exportPath: "~/Documents/InkdropNotes" });
@@ -98,3 +175,53 @@ test("no legacy warning when the stray directory is absent", (t) => {
 
   assert.deepEqual(notifications, []);
 });
+
+test("export writes every note of a 250-note vault", async (t) => {
+  const dir = tempDir(t);
+  stubInkdrop(t, { exportPath: dir, db: fakeDb(250) });
+
+  await plugin.exportNotesLocally();
+
+  const written = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
+  assert.equal(written.length, 250);
+});
+
+test("two consecutive exports leave the directory byte-identical", async (t) => {
+  const dir = tempDir(t);
+  stubInkdrop(t, { exportPath: dir, db: fakeDb(250) });
+
+  await plugin.exportNotesLocally();
+  const first = snapshot(dir);
+
+  await plugin.exportNotesLocally();
+  assert.deepEqual(snapshot(dir), first);
+});
+
+test("a failed read writes nothing and leaves the backup untouched", async (t) => {
+  const dir = tempDir(t);
+  stubInkdrop(t, { exportPath: dir, db: fakeDb(1200) });
+
+  await plugin.exportNotesLocally();
+  const before = snapshot(dir);
+
+  stubInkdrop(t, { exportPath: dir, db: fakeDb(1200, { failAtSkip: 500 }) });
+  await assert.rejects(() => plugin.exportNotesLocally(), /database unavailable/);
+
+  assert.deepEqual(snapshot(dir), before);
+});
+
+test("export creates the directory when it does not exist yet", async (t) => {
+  const dir = path.join(tempDir(t), "nested", "backup");
+  stubInkdrop(t, { exportPath: dir, db: fakeDb(3) });
+
+  await plugin.exportNotesLocally();
+
+  assert.equal(fs.readdirSync(dir).filter((f) => f.endsWith(".md")).length, 3);
+});
+
+function snapshot(dir) {
+  return fs
+    .readdirSync(dir)
+    .sort()
+    .map((name) => [name, fs.readFileSync(path.join(dir, name), "utf8")]);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "main": "./lib/autopush-notes",
   "version": "0.0.4",
   "description": "An Inkdrop plugin to export and back up notes to GitHub",
+  "scripts": {
+    "test": "node --test"
+  },
   "keywords": [
     "inkdrop",
     "backup",


### PR DESCRIPTION
Fixes three defects that meet in the same code path: the export read, and the cleanup that runs against it.

Closes #5, closes #7, closes #8.

## Why these three together

They are not merely adjacent. #7's ownership manifest **is** the guard #5 asks for, and #8 is what makes that guard point at the right directory.

Today deletion means *"remove everything not in the current batch"* — a set that **grows** when a read is incomplete. That is the mechanism of #5: reading 100 notes out of 250 deletes 150 backup files. The manifest changes the sentence to *"remove what I wrote before and no longer write"*, bounded by what was already owned. An incomplete read can then only miss a deletion, never widen one — the right failure direction for a backup tool.

And that guard reads `localExportPath`. With `~` unexpanded (#8) it would watch a stray folder under the Inkdrop process CWD while the user believes it protects `~/Documents/InkdropNotes`. A guard aimed at the wrong directory is worse than none: it reassures.

#12 (duplicate titles collide) stays out on purpose — it changes the output filename scheme and renames every file in the backup repo. Sequencing it after this PR makes its migration cleaner: the manifest allows a rename instead of a delete-then-recreate.

## Commits

Each one is green on its own, so the branch bisects.

| | | tests |
|---|---|---|
| `0816b36` | `fix: resolve ~ in the export path` (#8) | 6 |
| `4cff73a` | `fix: export every note, not just the first hundred` (#5) | 16 |
| `d08cf68` | `fix: only delete backup files the plugin itself wrote` (#7) | 21 |

## Verification

`npm test` — 21 tests, no new dependency, Node's built-in runner.

The suite is not vacuous: reverting the two fixes in place (single unpaginated read, `readdir`-based cleanup) fails **10 of the 21**.

Not covered: nothing has run inside Inkdrop. The tests exercise the logic against a fake `db`. The `db.notes.all()` contract — `totalRows`, `skip`, default `limit: 20` — comes from the Inkdrop docs, not from a live run. If `totalRows` counts anything other than the returned notes (deleted documents awaiting compaction, say), the completeness assertion would throw on a healthy vault. It is the only place in the diff resting on documentation rather than observation, and the only one that can fail an export that used to succeed.

## Deliberate omissions

**No refusal guard.** #7 suggests refusing to export when the target directory holds `.md` files and no manifest. That would reject every existing install on upgrade — a user with a configured absolute path has exactly that state today. A missing manifest therefore **adopts** the directory and deletes nothing.

**Residual risk kept:** a foreign `.md` whose name collides with a note title is still overwritten. Pre-existing behaviour, belongs to #12, unchanged by this PR.

**No automatic migration** of the stray `~` directory. It is not reliably locatable, and its `.git/config` holds a cleartext GitHub token (#6). It is detected at activation and reported, never moved.

## Upgrade impact

Users who kept the default path had their backup written to a stray `~` directory. After this change the plugin writes to `$HOME/Documents/InkdropNotes` — a fresh directory — so it re-inits a repo and pushes to a GitHub repo that already has history: `rejected: unrelated histories`. That failure lands in `pushNotesToGitHub()` and is tracked in #9, noted there.

## Depends on

#19, now merged. Before it, `lib/autopush-notes.js` could not be loaded by Node at all — it required `node-fetch`, declared as a dependency but never installed — so no test harness was possible on that base. #19 also removed a dead line inside `exportNotesLocally()`, the function this PR rewrites. This branch is rebased on `main` at `d98eb10`.
